### PR TITLE
Refactored `walk` arguments

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,24 +4,31 @@ var fs = require('fs'),
     Readable = require('stream').Readable,
     schemes = require('./schemes');
 
-module.exports = function (levels, options) {
-    options || (options = {});
+module.exports = function (levels, config) {
+    config || (config = {});
 
     var output = new Readable({ objectMode: true }),
-        defaultScheme = options.scheme || schemes.nested,
-        defaultNaming = options.naming ? bemNaming(options.naming) : bemNaming;
+        defaults = config.defaults || {},
+        levelConfigs = config.levels || {},
+        defaultScheme = defaults.scheme || schemes.nested,
+        defaultNaming = defaults.naming ? bemNaming(defaults.naming) : bemNaming;
 
     if (typeof defaultScheme === 'string') {
         defaultScheme = schemes[defaultScheme];
     }
 
-    levels = levels.map(function (level) {
-        var scheme = level && level.scheme,
-            naming = level && level.naming;
+    levels = levels.map(function (levelname) {
+        var config = levelConfigs[levelname],
+            scheme, naming;
+
+        if (config) {
+            scheme = config.scheme;
+            naming = config.naming;
+        }
 
         return {
-            path: typeof level === 'string' ? level : level.path,
-            scheme: typeof scheme === 'string' ? schemes[scheme] : (scheme || defaultScheme),
+            path: levelname,
+            walk: typeof scheme === 'string' ? schemes[scheme] : (scheme || defaultScheme),
             naming: naming ? bemNaming(naming) : defaultNaming
         };
     });
@@ -31,9 +38,10 @@ module.exports = function (levels, options) {
     }
 
     function scan(level, callback) {
-        var step = level.scheme(level.path, level.naming);
+        var levelname = level.path,
+            step = level.walk(levelname, level.naming);
 
-        walk(level.path, 1, null, callback);
+        walk(levelname, 1, null, callback);
 
         function walk(dir, depth, data, callback) {
             fs.readdir(dir, function (err, items) {

--- a/test/lib/assert.js
+++ b/test/lib/assert.js
@@ -1,9 +1,9 @@
 var promisify = require('bluebird').promisify,
     walk = require('../../lib/index');
 
-function assert(levels, opts, expected, cb) {
+function assert(levels, config, expected, cb) {
     var buffer = [],
-        walker = walk(levels, opts),
+        walker = walk(levels, config),
         hasError = false;
 
     walker.on('data', function (obj) {

--- a/test/lib/mock-and-assert.js
+++ b/test/lib/mock-and-assert.js
@@ -1,7 +1,7 @@
 var mock = require('mock-fs'),
     assert = require('./assert');
 
-module.exports = function (fs, levels, opts, expected) {
+module.exports = function (fs, levels, config, expected) {
     Object.keys(fs).forEach(function (level) {
         var content = fs[level];
 
@@ -12,7 +12,7 @@ module.exports = function (fs, levels, opts, expected) {
 
     mock(fs);
 
-    return assert(levels, opts, expected)
+    return assert(levels, config, expected)
         .finally(function () {
             mock.restore();
         });

--- a/test/lib/naming-assert.js
+++ b/test/lib/naming-assert.js
@@ -1,5 +1,5 @@
 var mockAndAssert = require('./mock-and-assert'),
-    opts = { scheme: 'flat' },
+    defaults = { scheme: 'flat' },
     conventions = {
         original: { elem: '__', mod: '_' },
         csswizardry: { elem: '__', mod: '--' },
@@ -11,17 +11,22 @@ var mockAndAssert = require('./mock-and-assert'),
     };
 
 module.exports = function (fs, expected) {
-    var levels = Object.keys(fs).map(function (levelPath) {
-        var naming = levelPath.indexOf('.') !== -1 && levelPath.split('.')[0],
+    var config = {
+        levels: {},
+        defaults: defaults
+    };
+
+    Object.keys(fs).forEach(function (levelname) {
+        var naming = levelname.indexOf('.') !== -1 && levelname.split('.')[0],
             convention = conventions[naming],
             info = {
-                path: levelPath
+                path: levelname
             };
 
         convention && (info.naming = convention);
 
-        return info;
+        config.levels[levelname] = info;
     });
 
-    return mockAndAssert(fs, levels, opts, expected);
+    return mockAndAssert(fs, Object.keys(config.levels), config, expected);
 };

--- a/test/lib/scheme-assert.js
+++ b/test/lib/scheme-assert.js
@@ -4,22 +4,27 @@ var mockAndAssert = require('./mock-and-assert'),
         nested: true
     };
 
-module.exports = function (fs, opts, expected) {
+module.exports = function (fs, defaults, expected) {
     if (arguments.length === 2) {
-        expected = opts;
-        opts = {};
+        expected = defaults;
+        defaults = {};
     }
 
-    var levels = Object.keys(fs).map(function (levelPath) {
-        var scheme = levelPath.indexOf('.') !== -1 && levelPath.split('.')[0],
+    var config = {
+        defaults: defaults,
+        levels: {}
+    };
+
+    Object.keys(fs).forEach(function (levelname) {
+        var scheme = levelname.indexOf('.') !== -1 && levelname.split('.')[0],
             info = {
-                path: levelPath
+                path: levelname
             };
 
         schemes[scheme] && (info.scheme = scheme);
 
-        return info;
+        config.levels[levelname] = info;
     });
 
-    return mockAndAssert(fs, levels, opts, expected);
+    return mockAndAssert(fs, Object.keys(config.levels), config, expected);
 };

--- a/test/schemes/flat.test.js
+++ b/test/schemes/flat.test.js
@@ -1,8 +1,8 @@
 var path = require('path'),
     schemeAssert = require('../lib/scheme-assert'),
-    opts = { scheme: 'flat' },
+    defaults = { scheme: 'flat' },
     assert = function (fs, expected) {
-        return schemeAssert(fs, opts, expected);
+        return schemeAssert(fs, defaults, expected);
     };
 
 describe('flat scheme', function () {


### PR DESCRIPTION
Resolved #15 

**1. The second argument now expects `config` instead of `options`.**

Options by default now should be specified in `config.defaults` instead of `options`.

*Before:*

```js
walk(['blocks'], { sheme: 'flat' });
```

*After:*

```js
var config = {
    defaults: { sheme: 'flat' }
};

walk(['blocks'], config);
```

**2. Info about levels (scheme and naming) now need specify in `config.levels` instead of `levels` arguments.**

The `levels` argument as `Array` is no longer supported.

*Before:*

```js
walk([{ path: 'blocks', sheme: 'flat' }]);
```

*After:*

```js
var config = {
    levels: {
        blocks: { sheme: 'flat' }
    }
};

walk(['blocks'], config);
```